### PR TITLE
Adding fetch_response method to the search class

### DIFF
--- a/lib/giantbomb.rb
+++ b/lib/giantbomb.rb
@@ -10,5 +10,5 @@ end
 end
 
 module GiantBomb
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/lib/giantbomb/search.rb
+++ b/lib/giantbomb/search.rb
@@ -85,10 +85,28 @@ module GiantBomb
     # @example
     #   search = GiantBomb::Search.new.query("Duke Nukem").fetch
     def fetch
+      fetch_response['results']
+    end
+
+    # Fetch the full response of the query, including metadata
+    # Keys returned:
+    #   status_code
+    #   error
+    #   number_of_total_results
+    #   number_of_page_results
+    #   limit
+    #   offset
+    #   results
+    # 
+    # @return [Hash] Hash of the api response
+    # @example
+    #   search = GiantBomb::Search.new.query("Duke Nukem").fetch_response
+    # @see http://api.giantbomb.com/documentation/#handling_responses
+    def fetch_response
       options = @params.merge(Api.config)
       response = Api.get(@resource, :query => options)
-      response['results']
+      response.to_hash
     end
-        
+
   end
 end


### PR DESCRIPTION
I've added a fetch_response method to the Search class to allow users to retrieve the metadata that is returned alongside the actual result set as a hash.

The fetch method on the Search class now calls the new fetch_response method and extracts the "results" key; thus retaining backwards-compatibility.
