### PR TITLE
Use resource IDs for singular resources in the new API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+PATH
+  remote: .
+  specs:
+    giantbomb (0.5.1)
+      httparty
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    httparty (0.10.2)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
+    multi_json (1.6.1)
+    multi_xml (0.5.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  giantbomb!

--- a/lib/giantbomb/api.rb
+++ b/lib/giantbomb/api.rb
@@ -1,7 +1,7 @@
 module GiantBomb
   module Api
     include HTTParty
-    base_uri 'www.giantbomb.com/api'
+    base_uri 'api.giantbomb.com'
     
     def self.config
       @@config

--- a/lib/giantbomb/api.rb
+++ b/lib/giantbomb/api.rb
@@ -1,7 +1,7 @@
 module GiantBomb
   module Api
     include HTTParty
-    base_uri 'api.giantbomb.com'
+    base_uri 'www.giantbomb.com/api'
     
     def self.config
       @@config

--- a/lib/giantbomb/character.rb
+++ b/lib/giantbomb/character.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Character < Resource
-    has_resource 'character', :plural => 'characters'
+    has_resource 'character', :plural => 'characters', :id => '3005'
     
     # http://api.giantbomb.com/documentation/#character
     @@fields = [

--- a/lib/giantbomb/company.rb
+++ b/lib/giantbomb/company.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Company < Resource
-    has_resource 'company', :plural => 'companies'
+    has_resource 'company', :plural => 'companies', :id => '3010'
     
     # http://api.giantbomb.com/documentation/#company
     @@fields = [

--- a/lib/giantbomb/concept.rb
+++ b/lib/giantbomb/concept.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Concept < Resource
-    has_resource 'concept', :plural => 'concepts'
+    has_resource 'concept', :plural => 'concepts', :id => '3015'
 
     # http://api.giantbomb.com/documentation/#concept
     @@fields = [

--- a/lib/giantbomb/franchise.rb
+++ b/lib/giantbomb/franchise.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Franchise < Resource
-    has_resource 'franchise', :plural => 'franchises'
+    has_resource 'franchise', :plural => 'franchises', :id => '3025'
 
     # http://api.giantbomb.com/documentation/#franchise
     @@fields = [

--- a/lib/giantbomb/game.rb
+++ b/lib/giantbomb/game.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Game < Resource
-    has_resource 'game', :plural => 'games'
+    has_resource 'game', :plural => 'games', :id => '3030'
     
     # http://api.giantbomb.com/documentation/#game
     @@fields = [
@@ -13,6 +13,7 @@ module GiantBomb
       :deck, # Brief summary of the game
       :description, # Description of the game
       :developers, # Companies that developed the game
+      :expected_release_day, # Expected day the game will be released in. The day is represented numerically.
       :expected_release_month, # Expected month the game will be released in. The month is represented numerically.
       :expected_release_quarter, # Expected quarter game will be released in. The quarter is represented numerically, where 1 = Q1, 2 = Q2, 3 = Q3, and 4 = Q4.
       :expected_release_year, # Expected year the game will be released in.

--- a/lib/giantbomb/location.rb
+++ b/lib/giantbomb/location.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Location < Resource
-    has_resource 'location', :plural => 'locations'
+    has_resource 'location', :plural => 'locations', :id => '3035'
 
     # http://api.giantbomb.com/documentation/#location
     @@fields = [

--- a/lib/giantbomb/object.rb
+++ b/lib/giantbomb/object.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class GameObject < Resource
-    has_resource 'object', :plural => 'objects'
+    has_resource 'object', :plural => 'objects', :id => '3055'
 
     # http://api.giantbomb.com/documentation/#object
     @@fields = [

--- a/lib/giantbomb/person.rb
+++ b/lib/giantbomb/person.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Person < Resource
-    has_resource 'person', :plural => 'people'
+    has_resource 'person', :plural => 'people', :id => '3040'
 
     # http://api.giantbomb.com/documentation/#person
     @@fields = [

--- a/lib/giantbomb/resource.rb
+++ b/lib/giantbomb/resource.rb
@@ -1,20 +1,26 @@
 module GiantBomb
   class Resource
     @@endpoints = {}
+    @@endpoint_id = {}
     
     def self.has_resource(singular=nil, opts={})
       @@endpoints[self.name.downcase] = { 
         :singular => singular.nil? ? "#{self.name.downcase}" : singular, 
         :plural => opts[:plural].nil? ? "#{self.name.downcase}s" : opts[:plural]
       }
+      @@endpoint_id[self.name.downcase] = opts[:id].nil? ? "" : "#{opts[:id]}-"
     end
     
     def self.endpoints
       @@endpoints[self.name.downcase]
     end
+
+    def self.endpoint_id
+      @@endpoint_id[self.name.downcase]
+    end
     
     def self.detail(id, conditions={})
-      search = GiantBomb::Search.new("/#{self.endpoints[:singular]}/#{id}/")
+      search = GiantBomb::Search.new("/#{self.endpoints[:singular]}/#{self.endpoint_id + id.to_s}/")
       search.filter(conditions)
       self.new(search.fetch)
     end

--- a/lib/giantbomb/video.rb
+++ b/lib/giantbomb/video.rb
@@ -1,6 +1,6 @@
 module GiantBomb
   class Video < Resource
-    has_resource 'video', :plural => 'videos'
+    has_resource 'video', :plural => 'videos', :id => '2300'
 
     # http://api.giantbomb.com/documentation/#video
     @@fields = [


### PR DESCRIPTION
With the [new API](http://www.giantbomb.com/forums/api-developers-3017/the-new-api-almost-the-same-as-the-old-api-1423775/), calls to singular resources require their resource IDs in the request path. (The linked post states that the current endpoints will be shut off in a few months.) This fork just passes resource IDs via has_resource and prepends them to singular resource ID in the request URL. It should fall back to the old style URL for resources that don't pass an ID.
