### PR TITLE
Updated to use newer giantbomb api fixes #2

### DIFF
--- a/lib/giantbomb.rb
+++ b/lib/giantbomb.rb
@@ -10,5 +10,5 @@ end
 end
 
 module GiantBomb
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/lib/giantbomb.rb
+++ b/lib/giantbomb.rb
@@ -10,5 +10,5 @@ end
 end
 
 module GiantBomb
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end

--- a/lib/giantbomb/api.rb
+++ b/lib/giantbomb/api.rb
@@ -8,8 +8,7 @@ module GiantBomb
     end
 
     def self.key(api_key)
-      #@@config = { :api_key => api_key, :format => 'json' }
-      @@config = { :api_key => "d3290640372f264c052d94299f176d41cb4ef8e3", :format => 'json' }
+      @@config = { :api_key => api_key, :format => 'json' }
     end
   end
 end

--- a/lib/giantbomb/api.rb
+++ b/lib/giantbomb/api.rb
@@ -1,15 +1,15 @@
 module GiantBomb
   module Api
     include HTTParty
-    base_uri 'api.giantbomb.com'
-    
+    base_uri 'http://www.giantbomb.com/api/'
+
     def self.config
       @@config
     end
-    
+
     def self.key(api_key)
-      @@config = { :api_key => api_key, :format => 'json' }
+      #@@config = { :api_key => api_key, :format => 'json' }
+      @@config = { :api_key => "d3290640372f264c052d94299f176d41cb4ef8e3", :format => 'json' }
     end
   end
-  
 end

--- a/lib/giantbomb/character.rb
+++ b/lib/giantbomb/character.rb
@@ -1,7 +1,7 @@
 module GiantBomb
   class Character < Resource
     has_resource 'character', :plural => 'characters', :id => '3005'
-    
+
     # http://api.giantbomb.com/documentation/#character
     @@fields = [
       :aliases, # List of aliases that the character is known by. A \n (newline) separates each alias.
@@ -30,10 +30,10 @@ module GiantBomb
       :real_name, # Real name of the character
       :site_detail_url # URL pointing to the character on Giant Bomb
     ]
-    
+
     @@fields.each do |field|
       attr_accessor field
     end
-    
+
   end
 end

--- a/lib/giantbomb/company.rb
+++ b/lib/giantbomb/company.rb
@@ -1,7 +1,7 @@
 module GiantBomb
   class Company < Resource
     has_resource 'company', :plural => 'companies', :id => '3010'
-    
+
     # http://api.giantbomb.com/documentation/#company
     @@fields = [
       :abbreviation, # Abbreviation of the company
@@ -33,7 +33,7 @@ module GiantBomb
       :site_detail_url, # URL pointing to the company on Giant Bomb
       :website # URL to the company website
     ]
-    
+
     @@fields.each do |field|
       attr_accessor field
     end

--- a/lib/giantbomb/concept.rb
+++ b/lib/giantbomb/concept.rb
@@ -23,14 +23,14 @@ module GiantBomb
       :name, # Name of the concept
       :objects, # Objects related to the concept
       :people, # People related to the concept
-      :platforms, # Platforms related to the concept
+      #:platforms, # Platforms related to the concept REMOVED not seen on http://www.giantbomb.com/api/documentation#toc-0-10
       :related_concepts, # Other concepts related to the concept
       :site_detail_url # URL pointing to the concept on Giant Bomb
     ]
-    
+
     @@fields.each do |field|
       attr_accessor field
     end
-    
+
   end
 end

--- a/lib/giantbomb/franchise.rb
+++ b/lib/giantbomb/franchise.rb
@@ -21,10 +21,10 @@ module GiantBomb
       :people, # People related to the franchise
       :site_detail_url # URL pointing to the franchise on Giant Bomb
     ]
-    
+
     @@fields.each do |field|
       attr_accessor field
     end
-    
+
   end
 end

--- a/lib/giantbomb/game.rb
+++ b/lib/giantbomb/game.rb
@@ -1,7 +1,7 @@
 module GiantBomb
   class Game < Resource
     has_resource 'game', :plural => 'games', :id => '3030'
-    
+
     # http://api.giantbomb.com/documentation/#game
     @@fields = [
       :aliases, # List of aliases the game is known by. A \n (newline) separates each alias.
@@ -44,7 +44,7 @@ module GiantBomb
       :themes, # Themes that encompass the game
       :videos # Videos associated to the game
     ]
-    
+
     @@fields.each do |field|
       attr_accessor field
     end

--- a/lib/giantbomb/resource.rb
+++ b/lib/giantbomb/resource.rb
@@ -2,15 +2,15 @@ module GiantBomb
   class Resource
     @@endpoints = {}
     @@endpoint_id = {}
-    
+
     def self.has_resource(singular=nil, opts={})
-      @@endpoints[self.name.downcase] = { 
-        :singular => singular.nil? ? "#{self.name.downcase}" : singular, 
+      @@endpoints[self.name.downcase] = {
+        :singular => singular.nil? ? "#{self.name.downcase}" : singular,
         :plural => opts[:plural].nil? ? "#{self.name.downcase}s" : opts[:plural]
       }
       @@endpoint_id[self.name.downcase] = opts[:id].nil? ? "" : "#{opts[:id]}-"
     end
-    
+
     def self.endpoints
       @@endpoints[self.name.downcase]
     end
@@ -18,13 +18,13 @@ module GiantBomb
     def self.endpoint_id
       @@endpoint_id[self.name.downcase]
     end
-    
+
     def self.detail(id, conditions={})
       search = GiantBomb::Search.new("/#{self.endpoints[:singular]}/#{self.endpoint_id + id.to_s}/")
       search.filter(conditions)
       self.new(search.fetch)
     end
-    
+
     def self.list(conditions={})
       search = GiantBomb::Search.new("/#{self.endpoints[:plural]}")
       search.filter(conditions)
@@ -32,7 +32,7 @@ module GiantBomb
         self.new(result)
       end
     end
-    
+
     def self.search(query)
       search = GiantBomb::Search.new
       search.resources("#{self.endpoints[:singular]}")
@@ -41,7 +41,7 @@ module GiantBomb
         self.new(result)
       end
     end
-    
+
     class << self
       alias_method :find, :search
     end
@@ -53,6 +53,6 @@ module GiantBomb
         end
       end
     end
-    
+
   end
 end

--- a/lib/giantbomb/search.rb
+++ b/lib/giantbomb/search.rb
@@ -112,7 +112,7 @@ module GiantBomb
     # @see http://api.giantbomb.com/documentation/#handling_responses
     def fetch_response
       options = @params.merge(Api.config)
-      response = Api.get('/search', :query => options)
+      response = Api.get(@resource, :query => options)
       response.to_hash
     end
 

--- a/lib/giantbomb/search.rb
+++ b/lib/giantbomb/search.rb
@@ -1,13 +1,13 @@
 module GiantBomb
   # Wrapper for the Giant Bomb Search resource
-  # 
-  # @see http://api.giantbomb.com/documentation/#search
+  #
+  # @see http://www.giantbomb.com/api/documentation/#search
   class Search
     include GiantBomb::Api
-    
+
     # @private
     attr_reader :query, :resource
-    
+
     # Creates a new search
     #
     # @example Initialize a Giant Bomb search
@@ -15,50 +15,51 @@ module GiantBomb
     #   search = GiantBomb::Search.new('game')
     def initialize(resource=nil)
       @params = {}
-      @resource = resource.nil? ? '/search' : resource
+      #@resource = resource.nil? ? '/search' : ''
+      @params[:resources] = resource
       self
     end
-    
+
     # @group Generic filters
-    
+
     # Only return the specified fields for the given resource
-    # 
+    #
     # @param fields [String] A comma delimited list of fields to return.
     # @return [GiantBomb::Search] self
     def fields(fields)
       @params[:field_list] = "#{fields}"
       self
     end
-    
+
     # Only return a limited number of resources
-    # 
+    #
     # @param limit [Integer] Nmber of items to limit by.
     # @return [GiantBomb::Search] self
     def limit(limit)
       @params[:limit] = "#{limit}"
       self
     end
-    
+
     # Only include resources starting from a given offset
-    # 
+    #
     # @param limit [Integer] Number of items to skip.
     # @return [GiantBomb::Search] self
     def offset(offset)
       @params[:offset] = "#{offset}"
       self
     end
-    
+
     # Search query
-    # 
+    #
     # @param query [String] The search query.
     # @return [GiantBomb::Search] self
     def query(query)
       @params[:query] = "#{query}"
       self
     end
-    
+
     # Only include items of the specified resources
-    # 
+    #
     # @param resources [String] A comma delimited list of resources to search.
     # @return [GiantBomb::Search] self
     def resources(resources)
@@ -66,7 +67,7 @@ module GiantBomb
       self
     end
 
-    # A convenience method that takes a hash where each key is 
+    # A convenience method that takes a hash where each key is
     # the symbol of a method, and each value is the parameters
     # passed to that method.
     def filter(conditions)
@@ -78,7 +79,7 @@ module GiantBomb
         end
       end
     end
-    
+
     # Fetch the results of the query
     #
     # @return [Array] Items that match the specified query.
@@ -97,14 +98,14 @@ module GiantBomb
     #   limit
     #   offset
     #   results
-    # 
+    #
     # @return [Hash] Hash of the api response
     # @example
     #   search = GiantBomb::Search.new.query("Duke Nukem").fetch_response
     # @see http://api.giantbomb.com/documentation/#handling_responses
     def fetch_response
       options = @params.merge(Api.config)
-      response = Api.get(@resource, :query => options)
+      response = Api.get('/search', :query => options)
       response.to_hash
     end
 

--- a/lib/giantbomb/search.rb
+++ b/lib/giantbomb/search.rb
@@ -13,10 +13,9 @@ module GiantBomb
     # @example Initialize a Giant Bomb search
     #   search = GiantBomb::Search.new
     #   search = GiantBomb::Search.new('game')
-    def initialize(resource=nil)
+    def initialize(resource='/search')
       @params = {}
-      #@resource = resource.nil? ? '/search' : ''
-      @params[:resources] = resource
+      @resource = resource
       self
     end
 

--- a/lib/giantbomb/search.rb
+++ b/lib/giantbomb/search.rb
@@ -66,6 +66,14 @@ module GiantBomb
       self
     end
 
+    def hash_to_filter(filter={})
+      filters = []
+      filter.each do |key, value|
+        filters << "#{key}:#{value}"
+      end
+      @params[:filter] = filters.join(',')
+    end
+
     # A convenience method that takes a hash where each key is
     # the symbol of a method, and each value is the parameters
     # passed to that method.


### PR DESCRIPTION
Uses giantbombs new api endpoint 'giantbomb.com/api' instead of 'api.giantbomb.com'

fixes #2
